### PR TITLE
Feat/manifest v3

### DIFF
--- a/getPageTitle.js
+++ b/getPageTitle.js
@@ -1,5 +1,5 @@
 (function() {
-    const port = chrome.extension.connect({
+    const port = chrome.runtime.connect({
         name: "Devtools.js Communication"
     });
     const inspectedWindowId = chrome.devtools.inspectedWindow.tabId;

--- a/manifest.json
+++ b/manifest.json
@@ -4,15 +4,17 @@
   "description": "Demo Panel devtools",
   "devtools_page": "devtools.html",
   "background": {
-    "scripts": [
-      "background.js"
-    ]
+    "service_worker": "background.js"
   },
   "permissions": [
-    "tabs",
+    "tabs"
+  ],
+  "host_permissions": [
     "http://*/*",
     "https://*/*"
   ],
-  "manifest_version": 2,
-  "content_security_policy": "script-src 'self' 'unsafe-eval'; object-src 'self'"
+  "manifest_version": 3,
+  "content_security_policy": {
+    "extension_pages": "script-src 'self'; object-src 'self'"
+  }
 }


### PR DESCRIPTION
The transition of Chrome extensions to Manifest V3


Manifest version 2 is deprecated, and support will be removed in 2023. See https://developer.chrome.com/blog/mv2-transition/ for more details.